### PR TITLE
Kinetic version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM osrf/ros:indigo-desktop-full
+FROM osrf/ros:kinetic-desktop-full
 
 RUN rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,3 @@
 
 Extends the `osrf/ros:indigo-desktop-full` image by adding opengl, glvnd and cuda 8.0. This makes opengl (i.e. `glxgears` and `gazebo`) work from any docker environment when used with nvidia-docker2, https://github.com/NVIDIA/nvidia-docker.
 
-## dockerhub
-
-https://hub.docker.com/r/lindwaltz/ros-indigo-desktop-full-nvidia/
-
-
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,5 @@ services:
   dev:
     build:
       context: .      
-    image: 'lindwaltz/ros-indigo-desktop-full-nvidia'
+    image: 'lindwaltz/ros-kinetic-desktop-full-nvidia'
     command: bash -c 'echo this is a base img'


### PR DESCRIPTION
Modified Dockerfile and docker_compose.yml to build from ros-kinetic-desktop-full docker image instead of ros-indigo-desktop-full. 

Removed dockerhub part of README.md since it's not pushed there yet